### PR TITLE
Updates the version of ldapjs to fix a bug during install

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "engines": ["node >=0.8.0"],
   "dependencies": {
-    "ldapjs": "0.5.6",
+    "ldapjs": "0.6.3",
     "bcrypt": "0.7.5",
     "lru-cache": "2.0.4"
   }


### PR DESCRIPTION
I've noticed that on node 0.10.x on Mac OS X the installation gives some warning, and then `require('ldapauth');` fails as well. This solves the problem.
