### PR TITLE
Updating ldapjs and bcrypt to support io.js and node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "assert-plus": "0.1.4",
     "backoff": "2.3.0",
-    "bcrypt": "0.7.5",
-    "ldapjs": "git+ssh://git@github.com:mcavage/node-ldapjs.git#fa1b8c4",
+    "bcrypt": "~0.8.1",
+    "ldapjs": "~0.7.1",
     "lru-cache": "2.0.4",
     "once": "1.3.0"
   }


### PR DESCRIPTION
Updating modules because node-ldapauth doesn't works with the last node.js update (and with io.js too). 